### PR TITLE
Update MaintenanceService.php

### DIFF
--- a/src/MaintenanceService.php
+++ b/src/MaintenanceService.php
@@ -60,7 +60,7 @@ class MaintenanceService
                 }
             }
             if ($from && $until) {
-                if ($from < $until) {
+                if ($from <= $until) {
                     if ($this->currentDate < $from || $this->currentDate > $until) {
                         return false;
                     }


### PR DESCRIPTION
I moved the defaults from maintenance.xaml to env, so from/until are always set. I set them to "01.01.1970 00:00:00" so I'd have a reminder of the format in my .env.local but wouldn't activate the maintenance-mode. Kept wondering why I couldn't exit maintenance:
app.NOTICE: Maintenance mode is active from 01.01.1970 00:00:00 to 01.01.1970 00:00:00
You could fix it by setting until to one second later, but changing the check to "$from <= $until" seemed more user friendly as setting both variables to the same time would mean "no maintenance":