### PR TITLE
This works with Symfony 5

### DIFF
--- a/src/EventListener/MaintenanceListener.php
+++ b/src/EventListener/MaintenanceListener.php
@@ -2,7 +2,6 @@
 namespace BretRZaun\MaintenanceBundle\EventListener;
 
 use BretRZaun\MaintenanceBundle\MaintenanceService;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;

--- a/src/EventListener/MaintenanceListener.php
+++ b/src/EventListener/MaintenanceListener.php
@@ -5,6 +5,7 @@ use BretRZaun\MaintenanceBundle\MaintenanceService;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Twig\Environment;
 
@@ -27,7 +28,7 @@ class MaintenanceListener
         $this->maintenanceService = $maintenanceService;
     }
 
-    public function onKernelRequest(GetResponseEvent $event): void
+    public function onKernelRequest(RequestEvent $event): void
     {
         if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
             return;

--- a/tests/MaintenanceListenerTest.php
+++ b/tests/MaintenanceListenerTest.php
@@ -9,7 +9,7 @@ use BretRZaun\MaintenanceBundle\EventListener\MaintenanceListener;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Twig\Environment;
 
@@ -55,7 +55,7 @@ class MaintenanceListenerTest extends KernelTestCase
           $server['REMOTE_ADDR'] = $context['clientIp'];
         }
         $request = new Request([], [], [], [] ,[], $server);
-        $event = new GetResponseEvent(self::$kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new RequestEvent(self::$kernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $listener->onKernelRequest($event);
 
         $response = $event->getResponse();


### PR DESCRIPTION
This pull request makes MaintenanceBundle work with Symfony5, by using `RequestEvent` instead of `GetResponseEvent`.