### PR TITLE
Make it ready for twig 3.

### DIFF
--- a/src/Twig/Extension.php
+++ b/src/Twig/Extension.php
@@ -4,6 +4,7 @@ namespace BretRZaun\MaintenanceBundle\Twig;
 use BretRZaun\MaintenanceBundle\MaintenanceService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\TwigFunction;
 
 class Extension extends \Twig\Extension\AbstractExtension
 {
@@ -26,8 +27,8 @@ class Extension extends \Twig\Extension\AbstractExtension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('maintenance_mode', [$this, 'maintenanceMode']),
-            new \Twig_SimpleFunction('maintenance_mode_allowed', [$this, 'maintenanceModeAllowed'])
+            new TwigFunction('maintenance_mode', [$this, 'maintenanceMode']),
+            new TwigFunction('maintenance_mode_allowed', [$this, 'maintenanceModeAllowed'])
         ];
     }
 


### PR DESCRIPTION
[Twig_SimpleFunction was deprecated in twig 2](https://twig.symfony.com/doc/1.x/deprecated.html#functions), and is removed in twig 3. This pull request makes the MaintenanceBundle ready for twig 3.