### PR TITLE
Fix Symfony version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
     },
     "require": {
         "php": ">=7.2",
-        "symfony/yaml": "^4.0|^5.0",
-        "twig/twig": "^2.5|^3.0"
+        "symfony/yaml": "^4.0 || ^5.0",
+        "twig/twig": "^2.5 || ^3.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.0|^5.0",
-        "symfony/framework-bundle": "^4.0|^5.0",
-        "symfony/twig-bundle": "^4.0|^5.0",
-        "symfony/asset": "^4.0|^5.0",
-        "symfony/browser-kit": "^4.0|^5.0",
-        "symfony/translation": "^4.0|^5.0",
-        "symfony/var-dumper": "^4.1|^5.0"
+        "symfony/phpunit-bridge": "^4.0 || ^5.0",
+        "symfony/framework-bundle": "^4.0 || ^5.0",
+        "symfony/twig-bundle": "^4.0 || ^5.0",
+        "symfony/asset": "^4.0 || ^5.0",
+        "symfony/browser-kit": "^4.0 || ^5.0",
+        "symfony/translation": "^4.0 || ^5.0",
+        "symfony/var-dumper": "^4.1 || ^5.0"
     },
     "scripts": {
         "test": "simple-phpunit"


### PR DESCRIPTION
Version Range needs a double pipe (||) to be treated as a **logical OR**.
https://getcomposer.org/doc/articles/versions.md#version-range